### PR TITLE
Fix possible compilation error in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "pug": "^2.0.0-beta11",
     "stylus": "^0.54.0",
     "just-try": "^2.0.1",
-    "js-yaml": "^3.6.1"
+    "js-yaml": "^3.6.1",
+    "less": "^2.7.2"
   },
   "scripts": {
-    "compile": "./script/compile.js",
+    "compile": "node ./script/compile.js",
     "preview": "zsh -c 'sensible-browser ./out/index.html &; exit'",
     "test": "npm run compile"
   },


### PR DESCRIPTION
Add less@"^2.7.2"
Use "node" before "./script/compile.js"